### PR TITLE
Sensor name and path added

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This adapter adds "luftdaten.info" sensor data to your ioBroker installation. Yo
 
 ## Changelog
 
+### 0.0.3
+
+* (pix) path and sensor name added
+
 ### 0.0.1
 
 * (klein0r) initial release

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ This adapter adds "luftdaten.info" sensor data to your ioBroker installation. Yo
 
 ## Changelog
 
-### 0.0.3
+### 0.0.4
+* (pix) path is IP if sensor is local
 
+### 0.0.3
 * (pix) path and sensor name added
 
 ### 0.0.1
-
 * (klein0r) initial release
 
 ## License

--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -3,5 +3,6 @@
   "Local": "Lokal",
   "Remote": "Remote",
   "Sensor Identifier": "Sensor Kennung",
-  "IP (when local) or ID (when remote)": "IP (wenn lokal) oder ID (wenn Remote)"
+  "IP (when local) or ID (when remote)": "IP (wenn lokal) oder ID (wenn Remote)",
+  "Individual name for sensor": "Eigener Name für diesen Sensor"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -3,5 +3,6 @@
   "Local": "Local",
   "Remote": "Remote",
   "Sensor Identifier": "Sensor Identifier",
-  "IP (when local) or ID (when remote)": "IP (when local) or ID (when remote)"
+  "IP (when local) or ID (when remote)": "IP (when local) or ID (when remote)",
+  "Individual name for sensor": "Individual name for sensor"
 }

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -81,10 +81,15 @@
                     </select>
                     <label for="sensorType" class="translate">Sensor Type</label>
                 </div>
-                <div class="input-field col s12 m8">
+                <div class="input-field col s12 m4">
                     <input class="value" id="sensorIdentifier" type="text">
                     <label for="sensorIdentifier" class="translate">Sensor Identifier</label>
                     <span class="translate">IP (when local) or ID (when remote)</span>
+                </div>
+                <div class="input-field col s12 m4">
+                    <input class="value" id="sensorName" type="text">
+                    <label for="sensorName" class="translate">Sensor Name</label>
+                    <span class="translate">Individual name for sensor</span>
                 </div>
             </div>
         </div>

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
     "common": {
         "name": "luftdaten",
-        "version": "0.0.2",
+        "version": "0.0.3",
         "news": {
+            "0.0.3": {
+                "en": "added path an sensor name",
+                "de": "Objektpfad und Sensorname"
+            }
             "0.0.2": {
                 "en": "initial adapter",
                 "de": "Initiale Version"

--- a/io-package.json
+++ b/io-package.json
@@ -1,9 +1,13 @@
 {
     "common": {
         "name": "luftdaten",
-        "version": "0.0.3",
+        "version": "0.0.4",
         "news": {
-            "0.0.3": {
+            "0.0.4": {
+                "en": "path can be ip if sensor type is local",
+                "de": "IP-Adresse als Pfad bei lokalem Sensor"
+            },
+	    "0.0.3": {
                 "en": "added path an sensor name",
                 "de": "Objektpfad und Sensorname"
             },

--- a/io-package.json
+++ b/io-package.json
@@ -6,7 +6,7 @@
             "0.0.3": {
                 "en": "added path an sensor name",
                 "de": "Objektpfad und Sensorname"
-            }
+            },
             "0.0.2": {
                 "en": "initial adapter",
                 "de": "Initiale Version"

--- a/main.js
+++ b/main.js
@@ -16,10 +16,10 @@ function main() {
     var sensorType = adapter.config.sensorType;
     var sensorIdentifier = adapter.config.sensorIdentifier;
     var sensorName = (adapter.config.sensorName === "") ? sensorIdentifier : adapter.config.sensorName;
-    var path = (sensorType == "local") ? adapter.config.sensorIdentifer.replace("."/g, '_') + "." : adapter.config.sensorIdentifier + ".";
-    adapter.log.info('sensor type: ' + sensorType);
-    adapter.log.info('sensor identifier: ' + sensorIdentifier);
-    adapter.log.info('sensor name: ' + sensorName);
+    var path = (sensorType == "local") ? adapter.config.sensorIdentifer.replace(/./g,"_") + "." : adapter.config.sensorIdentifier + ".";
+    adapter.log.debug('sensor type: ' + sensorType);
+    adapter.log.debug('sensor identifier: ' + sensorIdentifier);
+    adapter.log.debug('sensor name: ' + sensorName);
     adapter.setObjectNotExists(path + 'Name', {
         type: 'state',
             common: {
@@ -31,7 +31,7 @@ function main() {
     });
     adapter.setState(path + 'Name', {val: sensorName, ack: true});
     if (sensorType == "local") {
-        adapter.log.info('local request');
+        adapter.log.debug('local request');
         request(
             {
                 url: "http://" + sensorIdentifier + "/data.json",
@@ -64,7 +64,7 @@ function main() {
             }
         );
     } else if (sensorType == "remote") {
-        adapter.log.info('remote request');
+        adapter.log.debug('remote request');
         request(
             {
                 url: "http://api.luftdaten.info/v1/sensor/" + sensorIdentifier + "/",

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ function main() {
     var sensorType = adapter.config.sensorType;
     var sensorIdentifier = adapter.config.sensorIdentifier;
     var sensorName = (adapter.config.sensorName === "") ? sensorIdentifier : adapter.config.sensorName;
-    var path = (sensorType == "local") ? adapter.config.sensorIdentifer.replace(/./g,"_") + "." : adapter.config.sensorIdentifier + ".";
+    var path = (sensorType == "local") ? sensorIdentifier.replace(/./g,"_") + "." : sensorIdentifier + ".";
     adapter.log.debug('sensor type: ' + sensorType);
     adapter.log.debug('sensor identifier: ' + sensorIdentifier);
     adapter.log.debug('sensor name: ' + sensorName);

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ function main() {
     var sensorType = adapter.config.sensorType;
     var sensorIdentifier = adapter.config.sensorIdentifier;
     var sensorName = (adapter.config.sensorName === "") ? sensorIdentifier : adapter.config.sensorName;
-    var path = (sensorType == "local") ? "local." : adapter.config.sensorIdentifier + ".";
+    var path = (sensorType == "local") ? adapter.config.sensorIdentifer.replace("."/g, '_') + "." : adapter.config.sensorIdentifier + ".";
     adapter.log.info('sensor type: ' + sensorType);
     adapter.log.info('sensor identifier: ' + sensorIdentifier);
     adapter.log.info('sensor name: ' + sensorName);

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ function main() {
     var sensorType = adapter.config.sensorType;
     var sensorIdentifier = adapter.config.sensorIdentifier;
     var sensorName = adapter.config.sensorName;
-    sensorName = (sensorName.length === 0) ? sensorIdentifier : sensorName;
+    sensorName = (sensorName) ? sensorName : sensorIdentifier;
     adapter.log.info('sensor type: ' + sensorType);
     adapter.log.info('sensor identifier: ' + sensorIdentifier);
     adapter.log.info('sensor name: ' + sensorName);

--- a/main.js
+++ b/main.js
@@ -16,10 +16,11 @@ function main() {
     var sensorType = adapter.config.sensorType;
     var sensorIdentifier = adapter.config.sensorIdentifier;
     var sensorName = (adapter.config.sensorName === "") ? sensorIdentifier : adapter.config.sensorName;
+    var path = (sensorType == "local") ? "local." : adapter.config.sensorIdentifier + ".";
     adapter.log.info('sensor type: ' + sensorType);
     adapter.log.info('sensor identifier: ' + sensorIdentifier);
     adapter.log.info('sensor name: ' + sensorName);
-    adapter.setObjectNotExists('Name', {
+    adapter.setObjectNotExists(path + 'Name', {
         type: 'state',
             common: {
                 name: 'Name',

--- a/main.js
+++ b/main.js
@@ -15,8 +15,7 @@ function main() {
 
     var sensorType = adapter.config.sensorType;
     var sensorIdentifier = adapter.config.sensorIdentifier;
-    var sensorName = adapter.config.sensorName;
-    sensorName = (sensorName) ? sensorName : sensorIdentifier;
+    var sensorName = (adapter.config.sensorName === "") ? sensorIdentifier : adapter.config.sensorName;
     adapter.log.info('sensor type: ' + sensorType);
     adapter.log.info('sensor identifier: ' + sensorIdentifier);
     adapter.log.info('sensor name: ' + sensorName);

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ function main() {
     var sensorType = adapter.config.sensorType;
     var sensorIdentifier = adapter.config.sensorIdentifier;
     var sensorName = (adapter.config.sensorName === "") ? sensorIdentifier : adapter.config.sensorName;
-    var path = (sensorType == "local") ? sensorIdentifier.replace(/./g,"_") + "." : sensorIdentifier + ".";
+    var path = (sensorType == "local") ? sensorIdentifier.replace(/\./g,"_") + "." : sensorIdentifier + ".";
     adapter.log.debug('sensor type: ' + sensorType);
     adapter.log.debug('sensor identifier: ' + sensorIdentifier);
     adapter.log.debug('sensor name: ' + sensorName);

--- a/main.js
+++ b/main.js
@@ -29,7 +29,7 @@ function main() {
             },
         native: {}
     });
-    adapter.setState('Name', {val: sensorName, ack: true});
+    adapter.setState(path + 'Name', {val: sensorName, ack: true});
     if (sensorType == "local") {
         adapter.log.info('local request');
         request(
@@ -45,7 +45,7 @@ function main() {
                     for (var key in content.sensordatavalues) {
                         var obj = content.sensordatavalues[key];
 
-                        adapter.setObjectNotExists(obj.value_type, {
+                        adapter.setObjectNotExists(path + obj.value_type, {
                             type: 'state',
                             common: {
                                 name: obj.value_type,
@@ -55,7 +55,7 @@ function main() {
                             native: {}
                         });
 
-                        adapter.setState(obj.value_type, {val: obj.value, ack: true});
+                        adapter.setState(path + obj.value_type, {val: obj.value, ack: true});
                     }
 
                 } else {
@@ -78,7 +78,7 @@ function main() {
                     for (var key in content[0].sensordatavalues) {
                         var obj = content[0].sensordatavalues[key];
 
-                        adapter.setObjectNotExists('SDS_' + obj.value_type, {
+                        adapter.setObjectNotExists(path + 'SDS_' + obj.value_type, {
                             type: 'state',
                             common: {
                                 name: 'SDS_' + obj.value_type,
@@ -88,7 +88,7 @@ function main() {
                             native: {}
                         });
 
-                        adapter.setState('SDS_' + obj.value_type, {val: obj.value, ack: true});
+                        adapter.setState(path + 'SDS_' + obj.value_type, {val: obj.value, ack: true});
                     }
 
                 } else {

--- a/main.js
+++ b/main.js
@@ -15,13 +15,23 @@ function main() {
 
     var sensorType = adapter.config.sensorType;
     var sensorIdentifier = adapter.config.sensorIdentifier;
-
+    var sensorName = adapter.config.sensorName;
+    sensorName = (sensorName.length === 0) ? sensorIdentifier : sensorName;
     adapter.log.info('sensor type: ' + sensorType);
     adapter.log.info('sensor identifier: ' + sensorIdentifier);
-
+    adapter.log.info('sensor name: ' + sensorName);
+    adapter.setObjectNotExists('Name', {
+        type: 'state',
+            common: {
+                name: 'Name',
+                type: 'string',
+                role: 'text'
+            },
+        native: {}
+    });
+    adapter.setState('Name', {val: sensorName, ack: true});
     if (sensorType == "local") {
         adapter.log.info('local request');
-
         request(
             {
                 url: "http://" + sensorIdentifier + "/data.json",
@@ -55,7 +65,6 @@ function main() {
         );
     } else if (sensorType == "remote") {
         adapter.log.info('remote request');
-
         request(
             {
                 url: "http://api.luftdaten.info/v1/sensor/" + sensorIdentifier + "/",

--- a/main.js
+++ b/main.js
@@ -15,8 +15,8 @@ function main() {
 
     var sensorType = adapter.config.sensorType;
     var sensorIdentifier = adapter.config.sensorIdentifier;
-    var sensorName = (adapter.config.sensorName === "") ? sensorIdentifier : adapter.config.sensorName;
-    var path = (sensorType == "local") ? sensorIdentifier.replace(/\./g,"_") + "." : sensorIdentifier + ".";
+    let sensorName = (adapter.config.sensorName === "") ? sensorIdentifier : adapter.config.sensorName;
+    let path = (sensorType == "local") ? sensorIdentifier.replace(/\./g,"_") + "." : sensorIdentifier + ".";
     adapter.log.debug('sensor type: ' + sensorType);
     adapter.log.debug('sensor identifier: ' + sensorIdentifier);
     adapter.log.debug('sensor name: ' + sensorName);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     {
       "name": "Matthias Kleine",
       "email": "info@haus-automatisierung.com"
+    },
+    {
+      "name": "Pix",
+      "email": "pix---@hotmail.com"
     }
   ],
   "homepage": "https://github.com/klein0r/ioBroker.luftdaten",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.luftdaten",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "ioBroker luftdaten Adapter",
   "author": {
     "name": "Matthias Kleine",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.luftdaten",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "ioBroker luftdaten Adapter",
   "author": {
     "name": "Matthias Kleine",


### PR DESCRIPTION
Hello,
I have added a sensor name object to get a better overview when monitoring different sensors.
In addition to that I build a new path structure like adaptername.instance.sensorid.SDS_Px

If no sensorname is given in the settings the sensorid will be used. 

**Todo**
- if sensor type is local use ip in the path (replace "." with "_" before, like sonos adapter)
- later: ability to add more sensors to one instance instead of adding an instance for each sensor